### PR TITLE
Fix typo

### DIFF
--- a/src/main/java/org/sonar/plugins/scmstats/ScmStatsPlugin.java
+++ b/src/main/java/org/sonar/plugins/scmstats/ScmStatsPlugin.java
@@ -78,7 +78,7 @@ public final class ScmStatsPlugin extends SonarPlugin {
 
             PropertyDefinition.builder(ScmStatsConstants.PERIOD_3).
               defaultValue("0").
-              name("Period #2").
+              name("Period #3").
               description("See description of Period #1 property. If it's set to a non-positive value, then it's ignored").
               index(3).
               onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE).


### PR DESCRIPTION
CC - Fix typo where "Period #2" appears twice in settings under SonarQube > General Settings > Scm Stats. The 2nd instance should read "Period #3"